### PR TITLE
Fix type of ShipEngine speed property

### DIFF
--- a/models/ShipEngine.json
+++ b/models/ShipEngine.json
@@ -21,7 +21,7 @@
       "$ref": "./ShipCondition.json"
     },
     "speed": {
-      "type": "number",
+      "type": "integer",
       "minimum": 1
     },
     "requirements": {


### PR DESCRIPTION
I'm using the SpaceTraders API through a Python client generated by openapi-generator, and I was getting a validation error from it on the `speed` property of `ShipEngine` because it thinks it should be a float but it actually received an integer.