### PR TITLE
fix invalid member name in the list of required members

### DIFF
--- a/models/ShipRegistration.json
+++ b/models/ShipRegistration.json
@@ -18,7 +18,7 @@
   },
   "required": [
     "name",
-    "faction",
+    "factionSymbol",
     "role"
   ]
 }


### PR DESCRIPTION
There is no member named `faction` in `ShipRegistration`.

close #27