### PR TITLE
Add a github action that generates a couple of clients using openapi generator

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,15 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     name: Generate Clients
     steps:
-
     - uses: actions/checkout@v2
 
-    - uses: openapi-generators/openapitools-generator-action@v1
+    - name: Typescript Axios
+      uses: openapi-generators/openapitools-generator-action@v1
       with:
-        generator: typescript-angular
+        generator: typescript-axios
         openapi-file: ./reference/SpaceTraders.json
 
-    - uses: openapi-generators/openapitools-generator-action@v1
+    - name: Dart
+      uses: openapi-generators/openapitools-generator-action@v1
       with:
         generator: dart
         openapi-file: ./reference/SpaceTraders.json

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,17 @@
+name: Validate
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  generate-client:
+    runs-on: ubuntu-latest
+    name: Generate Angular Client 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: openapi-generators/openapitools-generator-action@v1
+        with:
+          generator: typescript-angular

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: Validate
+name: Validate OpenAPI Spec
 
 on:
   push:
@@ -7,11 +7,12 @@ on:
     branches: [ "main" ]
 
 jobs:
-  generate-client:
+  generate:
     runs-on: ubuntu-latest
-    name: Generate Angular Client 
+    name: Angular Client 
     steps:
       - uses: actions/checkout@v2
       - uses: openapi-generators/openapitools-generator-action@v1
         with:
           generator: typescript-angular
+          openapi-file: ./reference/SpaceTraders.json

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,10 +9,17 @@ on:
 jobs:
   generate:
     runs-on: ubuntu-latest
-    name: Angular Client 
+    name: Generate Clients
     steps:
-      - uses: actions/checkout@v2
-      - uses: openapi-generators/openapitools-generator-action@v1
-        with:
-          generator: typescript-angular
-          openapi-file: ./reference/SpaceTraders.json
+
+    - uses: actions/checkout@v2
+
+    - uses: openapi-generators/openapitools-generator-action@v1
+      with:
+        generator: typescript-angular
+        openapi-file: ./reference/SpaceTraders.json
+
+    - uses: openapi-generators/openapitools-generator-action@v1
+      with:
+        generator: dart
+        openapi-file: ./reference/SpaceTraders.json

--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -1143,17 +1143,6 @@
               }
             },
             "description": "Successfully delivered cargo to contract."
-          },
-          "": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {}
-                }
-              }
-            }
           }
         },
         "security": [

--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -1143,6 +1143,17 @@
               }
             },
             "description": "Successfully delivered cargo to contract."
+          },
+          "": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
           }
         },
         "security": [


### PR DESCRIPTION
This was not requested, so no worries if it's not needed.

Adds a quick layer of validation at CI level.

1 file added `.github/workflows/validate.yml`

squash and merge - I have some testing commits that shouldn't be on master