### PR TITLE
waypoint and system symbol mocks

### DIFF
--- a/models/Chart.json
+++ b/models/Chart.json
@@ -3,7 +3,7 @@
   "description": "The chart of a system or waypoint, which makes the location visible to other agents.",
   "properties": {
     "waypointSymbol": {
-      "type": "string",
+      "$ref": "./WaypointSymbol.json",
       "description": "The symbol of the waypoint."
     },
     "submittedBy": {

--- a/models/MarketTransaction.json
+++ b/models/MarketTransaction.json
@@ -2,7 +2,7 @@
   "type": "object",
   "properties": {
     "waypointSymbol": {
-      "type": "string",
+      "$ref": "./WaypointSymbol.json",
       "description": "The symbol of the waypoint where the transaction took place."
     },
     "shipSymbol": {

--- a/models/ScannedWaypoint.json
+++ b/models/ScannedWaypoint.json
@@ -3,16 +3,14 @@
   "type": "object",
   "properties": {
     "symbol": {
-      "type": "string",
-      "minLength": 1,
+      "$ref": "./WaypointSymbol.json",
       "description": "Symbol of the waypoint."
     },
     "type": {
       "$ref": "./WaypointType.json"
     },
     "systemSymbol": {
-      "type": "string",
-      "minLength": 1,
+      "$ref": "./SystemSymbol.json",
       "description": "Symbol of the system."
     },
     "x": {

--- a/models/ShipNav.json
+++ b/models/ShipNav.json
@@ -3,11 +3,11 @@
   "description": "The navigation information of the ship.",
   "properties": {
     "systemSymbol": {
-      "type": "string",
+      "$ref": "./SystemSymbol.json",
       "description": "The system symbol of the ship's current location."
     },
     "waypointSymbol": {
-      "type": "string",
+      "$ref": "./WaypointSymbol.json",
       "description": "The waypoint symbol of the ship's current location, or if the ship is in-transit, the waypoint symbol of the ship's destination."
     },
     "route": {

--- a/models/ShipNavRouteWaypoint.json
+++ b/models/ShipNavRouteWaypoint.json
@@ -11,8 +11,7 @@
       "$ref": "./WaypointType.json"
     },
     "systemSymbol": {
-      "type": "string",
-      "minLength": 1,
+      "$ref": "./SystemSymbol.json",
       "description": "The symbol of the system the waypoint is in."
     },
     "x": {

--- a/models/ShipyardTransaction.json
+++ b/models/ShipyardTransaction.json
@@ -3,7 +3,7 @@
   "description": "Results of a transaction with a shipyard.",
   "properties": {
     "waypointSymbol": {
-      "type": "string",
+      "$ref": "./WaypointSymbol.json",
       "description": "The symbol of the waypoint where the transaction took place."
     },
     "shipSymbol": {

--- a/models/SystemSymbol.json
+++ b/models/SystemSymbol.json
@@ -1,0 +1,7 @@
+{
+  "type": "string",
+  "minLength": 1,
+  "x-faker": {
+    "fake": ["X1-{{random.alphaNumeric(5)}}"]
+  }
+}

--- a/models/SystemWaypoint.json
+++ b/models/SystemWaypoint.json
@@ -2,7 +2,7 @@
   "type": "object",
   "properties": {
     "symbol": {
-      "type": "string",
+      "$ref": "./WaypointSymbol.json",
       "description": "The symbol of the waypoint."
     },
     "type": {

--- a/models/Waypoint.json
+++ b/models/Waypoint.json
@@ -3,16 +3,14 @@
   "type": "object",
   "properties": {
     "symbol": {
-      "type": "string",
-      "minLength": 1,
+      "$ref": "./WaypointSymbol.json",
       "description": "Symbol fo the waypoint."
     },
     "type": {
       "$ref": "./WaypointType.json"
     },
     "systemSymbol": {
-      "type": "string",
-      "minLength": 1,
+      "$ref": "./SystemSymbol.json",
       "description": "The symbol of the system this waypoint belongs to."
     },
     "x": {

--- a/models/WaypointSymbol.json
+++ b/models/WaypointSymbol.json
@@ -1,0 +1,7 @@
+{
+  "type": "string",
+  "minLength": 1,
+  "x-faker": {
+    "fake": ["X1-{{random.alphaNumeric(5)}}-{{random.alphaNumeric(5)}}"]
+  }
+}


### PR DESCRIPTION
Resolves #52. I did so by creating `WaypointSymbol.json` and `SystemSymbol.json`. I tested the faking and response server, but I haven't tested the docs, so I don't know if the existing descriptions are overriden by the "$ref" or if it errors out completely.