### PR TITLE
fix a piece of documentation

### DIFF
--- a/models/SystemType.json
+++ b/models/SystemType.json
@@ -1,6 +1,6 @@
 {
   "type": "string",
-  "description": "The type of waypoint.",
+  "description": "The type of system.",
   "enum": [
     "NEUTRON_STAR",
     "RED_STAR",


### PR DESCRIPTION
can sometimes be confusing what enum type is being referred to, since most of these fields are just called "type" "string"