### PR TITLE
Various fixes: Shipyard.shiptyps.type, supply-contruction:201, enum normalizing

### DIFF
--- a/models/Shipyard.json
+++ b/models/Shipyard.json
@@ -16,7 +16,10 @@
           "type": {
             "$ref": "./ShipType.json"
           }
-        }
+        },
+        "required": [
+          "type"
+        ]
       }
     },
     "transactions": {

--- a/models/ShipyardShip.json
+++ b/models/ShipyardShip.json
@@ -58,6 +58,7 @@
     }
   },
   "required": [
+    "type",
     "symbol",
     "name",
     "description",

--- a/models/WaypointModifier.json
+++ b/models/WaypointModifier.json
@@ -2,15 +2,7 @@
   "type": "object",
   "properties": {
     "symbol": {
-      "type": "string",
-      "description": "The unique identifier of the modifier.",
-      "enum": [
-        "STRIPPED",
-        "UNSTABLE",
-        "RADIATION_LEAK",
-        "CRITICAL_LIMIT",
-        "CIVIL_UNREST"
-      ]
+      "$ref": "./WaypointModifierSymbol.json"
     },
     "name": {
       "type": "string",

--- a/models/WaypointModifierSymbol.json
+++ b/models/WaypointModifierSymbol.json
@@ -1,0 +1,11 @@
+{
+    "type": "string",
+    "description": "The unique identifier of the modifier.",
+    "enum": [
+        "STRIPPED",
+        "UNSTABLE",
+        "RADIATION_LEAK",
+        "CRITICAL_LIMIT",
+        "CIVIL_UNREST"
+    ]
+}

--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -867,7 +867,7 @@
           "description": ""
         },
         "responses": {
-          "200": {
+          "201": {
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
Not sure it makes sense to ever have a response to ../shipyard where shipTypes has an element where the type is not provided.

net effect:

![image](https://github.com/SpaceTradersAPI/api-docs/assets/13543344/882207fb-ad4e-4131-a05e-ab2f012e5f41)
