### PR TITLE
Remove $ref siblings, Agent.shipCount NOT optional, typos

### DIFF
--- a/models/Agent.json
+++ b/models/Agent.json
@@ -37,6 +37,7 @@
     "symbol",
     "headquarters",
     "credits",
-    "startingFaction"
+    "startingFaction",
+    "shipCount"
   ]
 }

--- a/models/Chart.json
+++ b/models/Chart.json
@@ -3,8 +3,7 @@
   "description": "The chart of a system or waypoint, which makes the location visible to other agents.",
   "properties": {
     "waypointSymbol": {
-      "$ref": "./WaypointSymbol.json",
-      "description": "The symbol of the waypoint."
+      "$ref": "./WaypointSymbol.json"
     },
     "submittedBy": {
       "type": "string",

--- a/models/Contract.json
+++ b/models/Contract.json
@@ -22,8 +22,7 @@
       "description": "Type of contract."
     },
     "terms": {
-      "$ref": "./ContractTerms.json",
-      "description": "The terms to fulfill the contract."
+      "$ref": "./ContractTerms.json"
     },
     "accepted": {
       "type": "boolean",

--- a/models/ContractPayment.json
+++ b/models/ContractPayment.json
@@ -1,5 +1,6 @@
 {
   "type": "object",
+  "description": "Payments for the contract.",
   "properties": {
     "onAccepted": {
       "type": "integer",

--- a/models/ContractTerms.json
+++ b/models/ContractTerms.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "description": "Terms of the contract needed to fulfill it.",
+  "description": "The terms to fulfill the contract.",
   "properties": {
     "deadline": {
       "type": "string",
@@ -8,8 +8,7 @@
       "description": "The deadline for the contract."
     },
     "payment": {
-      "$ref": "./ContractPayment.json",
-      "description": "Payments for the contract."
+      "$ref": "./ContractPayment.json"
     },
     "deliver": {
       "type": "array",

--- a/models/Extraction.json
+++ b/models/Extraction.json
@@ -8,8 +8,7 @@
       "description": "Symbol of the ship that executed the extraction."
     },
     "yield": {
-      "$ref": "./ExtractionYield.json",
-      "description": "Yields from the extract operation."
+      "$ref": "./ExtractionYield.json"
     }
   },
   "required": [

--- a/models/ExtractionYield.json
+++ b/models/ExtractionYield.json
@@ -3,8 +3,7 @@
   "description": "A yield from the extraction operation.",
   "properties": {
     "symbol": {
-      "$ref": "./TradeSymbol.json",
-      "description": "Symbol of the good that was extracted."
+      "$ref": "./TradeSymbol.json"
     },
     "units": {
       "type": "integer",

--- a/models/Faction.json
+++ b/models/Faction.json
@@ -3,8 +3,7 @@
   "type": "object",
   "properties": {
     "symbol": {
-      "$ref": "./FactionSymbol.json",
-      "description": "Faction symbol."
+      "$ref": "./FactionSymbol.json"
     },
     "name": {
       "type": "string",

--- a/models/MarketTransaction.json
+++ b/models/MarketTransaction.json
@@ -2,8 +2,7 @@
   "type": "object",
   "properties": {
     "waypointSymbol": {
-      "$ref": "./WaypointSymbol.json",
-      "description": "The symbol of the waypoint where the transaction took place."
+      "$ref": "./WaypointSymbol.json"
     },
     "shipSymbol": {
       "type": "string",

--- a/models/ScannedWaypoint.json
+++ b/models/ScannedWaypoint.json
@@ -3,15 +3,13 @@
   "type": "object",
   "properties": {
     "symbol": {
-      "$ref": "./WaypointSymbol.json",
-      "description": "Symbol of the waypoint."
+      "$ref": "./WaypointSymbol.json"
     },
     "type": {
       "$ref": "./WaypointType.json"
     },
     "systemSymbol": {
-      "$ref": "./SystemSymbol.json",
-      "description": "Symbol of the system."
+      "$ref": "./SystemSymbol.json"
     },
     "x": {
       "type": "integer",

--- a/models/ShipNav.json
+++ b/models/ShipNav.json
@@ -3,12 +3,10 @@
   "description": "The navigation information of the ship.",
   "properties": {
     "systemSymbol": {
-      "$ref": "./SystemSymbol.json",
-      "description": "The system symbol of the ship's current location."
+      "$ref": "./SystemSymbol.json"
     },
     "waypointSymbol": {
-      "$ref": "./WaypointSymbol.json",
-      "description": "The waypoint symbol of the ship's current location, or if the ship is in-transit, the waypoint symbol of the ship's destination."
+      "$ref": "./WaypointSymbol.json"
     },
     "route": {
       "$ref": "./ShipNavRoute.json"

--- a/models/ShipNavRoute.json
+++ b/models/ShipNavRoute.json
@@ -6,9 +6,7 @@
       "$ref": "./ShipNavRouteWaypoint.json"
     },
     "departure": {
-      "deprecated": true,
-      "description": "Deprecated. Use origin instead.",
-      "$ref": "./ShipNavRouteWaypoint.json"
+      "$ref": "./ShipNavRouteWaypointDeprecated.json"
     },
     "origin": {
       "$ref": "./ShipNavRouteWaypoint.json"

--- a/models/ShipNavRouteWaypointDeprecated.json
+++ b/models/ShipNavRouteWaypointDeprecated.json
@@ -1,6 +1,7 @@
 {
-  "description": "The destination or departure of a ships nav route.",
   "type": "object",
+  "deprecated": true,
+  "description": "Deprecated. Use origin instead.",
   "properties": {
     "symbol": {
       "type": "string",
@@ -11,7 +12,8 @@
       "$ref": "./WaypointType.json"
     },
     "systemSymbol": {
-      "$ref": "./SystemSymbol.json"
+      "$ref": "./SystemSymbol.json",
+      "description": "The symbol of the system the waypoint is in."
     },
     "x": {
       "type": "integer",

--- a/models/ShipNavRouteWaypointDeprecated.json
+++ b/models/ShipNavRouteWaypointDeprecated.json
@@ -12,8 +12,7 @@
       "$ref": "./WaypointType.json"
     },
     "systemSymbol": {
-      "$ref": "./SystemSymbol.json",
-      "description": "The symbol of the system the waypoint is in."
+      "$ref": "./SystemSymbol.json"
     },
     "x": {
       "type": "integer",

--- a/models/ShipyardTransaction.json
+++ b/models/ShipyardTransaction.json
@@ -3,8 +3,7 @@
   "description": "Results of a transaction with a shipyard.",
   "properties": {
     "waypointSymbol": {
-      "$ref": "./WaypointSymbol.json",
-      "description": "The symbol of the waypoint where the transaction took place."
+      "$ref": "./WaypointSymbol.json"
     },
     "shipSymbol": {
       "type": "string",

--- a/models/Siphon.json
+++ b/models/Siphon.json
@@ -8,8 +8,7 @@
       "description": "Symbol of the ship that executed the siphon."
     },
     "yield": {
-      "$ref": "./SiphonYield.json",
-      "description": "Yields from the siphon operation."
+      "$ref": "./SiphonYield.json"
     }
   },
   "required": [

--- a/models/SiphonYield.json
+++ b/models/SiphonYield.json
@@ -3,8 +3,7 @@
   "description": "A yield from the siphon operation.",
   "properties": {
     "symbol": {
-      "$ref": "./TradeSymbol.json",
-      "description": "Symbol of the good that was siphoned."
+      "$ref": "./TradeSymbol.json"
     },
     "units": {
       "type": "integer",

--- a/models/SystemSymbol.json
+++ b/models/SystemSymbol.json
@@ -1,5 +1,6 @@
 {
   "type": "string",
+  "description": "The symbol of the system.",
   "minLength": 1,
   "x-faker": {
     "fake": ["X1-{{random.alphaNumeric(5)}}"]

--- a/models/SystemWaypoint.json
+++ b/models/SystemWaypoint.json
@@ -2,8 +2,7 @@
   "type": "object",
   "properties": {
     "symbol": {
-      "$ref": "./WaypointSymbol.json",
-      "description": "The symbol of the waypoint."
+      "$ref": "./WaypointSymbol.json"
     },
     "type": {
       "$ref": "./WaypointType.json"

--- a/models/Waypoint.json
+++ b/models/Waypoint.json
@@ -3,15 +3,13 @@
   "type": "object",
   "properties": {
     "symbol": {
-      "$ref": "./WaypointSymbol.json",
-      "description": "Symbol of the waypoint."
+      "$ref": "./WaypointSymbol.json"
     },
     "type": {
       "$ref": "./WaypointType.json"
     },
     "systemSymbol": {
-      "$ref": "./SystemSymbol.json",
-      "description": "The symbol of the system this waypoint belongs to."
+      "$ref": "./SystemSymbol.json"
     },
     "x": {
       "type": "integer",

--- a/models/Waypoint.json
+++ b/models/Waypoint.json
@@ -4,7 +4,7 @@
   "properties": {
     "symbol": {
       "$ref": "./WaypointSymbol.json",
-      "description": "Symbol fo the waypoint."
+      "description": "Symbol of the waypoint."
     },
     "type": {
       "$ref": "./WaypointType.json"

--- a/models/WaypointSymbol.json
+++ b/models/WaypointSymbol.json
@@ -1,5 +1,6 @@
 {
   "type": "string",
+  "description": "The symbol of the waypoint.",
   "minLength": 1,
   "x-faker": {
     "fake": ["X1-{{random.alphaNumeric(5)}}-{{random.alphaNumeric(5)}}"]

--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -254,8 +254,7 @@
               "schema": {
                 "properties": {
                   "faction": {
-                    "$ref": "../models/FactionSymbol.json",
-                    "example": "COSMIC"
+                    "$ref": "../models/FactionSymbol.json"
                   },
                   "symbol": {
                     "description": "Your desired agent symbol. This will be a unique name used to represent your agent, and will be the prefix for your ships.",


### PR DESCRIPTION
Please validate Agent.shipCount is actually always returned. It seems to be so not sure why it's optional in the schema. Let me know if there's a reason why it's optional, what that would mean, and can change the PR to put that in the description instead.