### PR TITLE
Ship Condition Update

### DIFF
--- a/models/RepairTransaction.json
+++ b/models/RepairTransaction.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "waypointSymbol": {
+      "$ref": "./WaypointSymbol.json"
+    },
+    "shipSymbol": {
+      "type": "string",
+      "description": "The symbol of the ship."
+    },
+    "totalPrice": {
+      "type": "integer",
+      "description": "The total price of the transaction.",
+      "minimum": 0
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The timestamp of the transaction."
+    }
+  },
+  "required": [
+    "waypointSymbol",
+    "shipSymbol",
+    "totalPrice",
+    "timestamp"
+  ],
+  "description": "Result of a repair transaction."
+}

--- a/models/ScrapTransaction.json
+++ b/models/ScrapTransaction.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "waypointSymbol": {
+      "$ref": "./WaypointSymbol.json"
+    },
+    "shipSymbol": {
+      "type": "string",
+      "description": "The symbol of the ship."
+    },
+    "totalPrice": {
+      "type": "integer",
+      "description": "The total price of the transaction.",
+      "minimum": 0
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The timestamp of the transaction."
+    }
+  },
+  "required": [
+    "waypointSymbol",
+    "shipSymbol",
+    "totalPrice",
+    "timestamp"
+  ],
+  "description": "Result of a scrap transaction."
+}

--- a/models/ShipComponentCondition.json
+++ b/models/ShipComponentCondition.json
@@ -1,0 +1,7 @@
+{
+  "type": "number",
+  "format": "double",
+  "description": "The repairable condition of a component. A value of 0 indicates the component needs significant repairs, while a value of 1 indicates the component is in near perfect condition. As the condition of a component is repaired, the overall integrity of the component decreases.",
+  "minimum": 0,
+  "maximum": 1
+}

--- a/models/ShipComponentIntegrity.json
+++ b/models/ShipComponentIntegrity.json
@@ -1,0 +1,7 @@
+{
+  "type": "number",
+  "format": "double",
+  "description": "The overall integrity of the component, which determines the performance of the component. A value of 0 indicates that the component is almost completely degraded, while a value of 1 indicates that the component is in near perfect condition. The integrity of the component is non-repairable, and represents permanent wear over time.",
+  "minimum": 0,
+  "maximum": 1
+}

--- a/models/ShipCondition.json
+++ b/models/ShipCondition.json
@@ -1,6 +1,0 @@
-{
-  "type": "integer",
-  "description": "Condition is a range of 0 to 100 where 0 is completely worn out and 100 is brand new.",
-  "minimum": 0,
-  "maximum": 100
-}

--- a/models/ShipConditionEvent.json
+++ b/models/ShipConditionEvent.json
@@ -1,0 +1,60 @@
+{
+  "type": "object",
+  "description": "An event that represents damage or wear to a ship's reactor, frame, or engine, reducing the condition of the ship.",
+  "properties": {
+    "symbol": {
+      "type": "string",
+      "enum": [
+        "REACTOR_OVERLOAD",
+        "ENERGY_SPIKE_FROM_MINERAL",
+        "SOLAR_FLARE_INTERFERENCE",
+        "COOLANT_LEAK",
+        "POWER_DISTRIBUTION_FLUCTUATION",
+        "MAGNETIC_FIELD_DISRUPTION",
+        "HULL_MICROMETEORITE_STRIKES",
+        "STRUCTURAL_STRESS_FRACTURES",
+        "CORROSIVE_MINERAL_CONTAMINATION",
+        "THERMAL_EXPANSION_MISMATCH",
+        "VIBRATION_DAMAGE_FROM_DRILLING",
+        "ELECTROMAGNETIC_FIELD_INTERFERENCE",
+        "IMPACT_WITH_EXTRACTED_DEBRIS",
+        "FUEL_EFFICIENCY_DEGRADATION",
+        "COOLANT_SYSTEM_AGEING",
+        "DUST_MICROABRASIONS",
+        "THRUSTER_NOZZLE_WEAR",
+        "EXHAUST_PORT_CLOGGING",
+        "BEARING_LUBRICATION_FADE",
+        "SENSOR_CALIBRATION_DRIFT",
+        "HULL_MICROMETEORITE_DAMAGE",
+        "SPACE_DEBRIS_COLLISION",
+        "THERMAL_STRESS",
+        "VIBRATION_OVERLOAD",
+        "PRESSURE_DIFFERENTIAL_STRESS",
+        "ELECTROMAGNETIC_SURGE_EFFECTS",
+        "ATMOSPHERIC_ENTRY_HEAT"
+      ]
+    },
+    "component": {
+      "type": "string",
+      "enum": [
+        "FRAME",
+        "REACTOR",
+        "ENGINE"
+      ]
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the event."
+    },
+    "description": {
+      "type": "string",
+      "description": "A description of the event."
+    }
+  },
+  "required": [
+    "symbol",
+    "component",
+    "name",
+    "description"
+  ]
+}

--- a/models/ShipEngine.json
+++ b/models/ShipEngine.json
@@ -21,7 +21,10 @@
       "description": "The description of the engine."
     },
     "condition": {
-      "$ref": "./ShipCondition.json"
+      "$ref": "./ShipComponentCondition.json"
+    },
+    "integrity": {
+      "$ref": "./ShipComponentIntegrity.json"
     },
     "speed": {
       "type": "integer",
@@ -35,6 +38,8 @@
   "required": [
     "symbol",
     "name",
+    "condition",
+    "performance",
     "description",
     "speed",
     "requirements"

--- a/models/ShipFrame.json
+++ b/models/ShipFrame.json
@@ -32,7 +32,10 @@
       "description": "Description of the frame."
     },
     "condition": {
-      "$ref": "./ShipCondition.json"
+      "$ref": "./ShipComponentCondition.json"
+    },
+    "integrity": {
+      "$ref": "./ShipComponentIntegrity.json"
     },
     "moduleSlots": {
       "type": "integer",
@@ -56,6 +59,8 @@
   "required": [
     "symbol",
     "name",
+    "condition",
+    "performance",
     "description",
     "moduleSlots",
     "mountingPoints",

--- a/models/ShipReactor.json
+++ b/models/ShipReactor.json
@@ -22,7 +22,10 @@
       "description": "Description of the reactor."
     },
     "condition": {
-      "$ref": "./ShipCondition.json"
+      "$ref": "./ShipComponentCondition.json"
+    },
+    "integrity": {
+      "$ref": "./ShipComponentIntegrity.json"
     },
     "powerOutput": {
       "type": "integer",
@@ -36,6 +39,8 @@
   "required": [
     "symbol",
     "name",
+    "condition",
+    "performance",
     "description",
     "powerOutput",
     "requirements"

--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -3622,6 +3622,216 @@
           "Fleet"
         ]
       }
+    },
+    "/my/ships/{shipSymbol}/scrap": {
+      "parameters": [
+        {
+          "description": "The ship symbol.",
+          "in": "path",
+          "name": "shipSymbol",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "x-preview-feature": true,
+        "description": "Get the amount of value that will be returned when scrapping a ship.",
+        "operationId": "get-scrap-ship",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "",
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "transaction": {
+                          "$ref": "../models/ScrapTransaction.json"
+                        }
+                      },
+                      "required": [
+                        "transaction"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successfully retrieved the amount of value that will be returned when scrapping a ship."
+          }
+        },
+        "security": [
+          {
+            "AgentToken": []
+          }
+        ],
+        "summary": "Get Scrap Ship",
+        "tags": [
+          "Fleet"
+        ]
+      },
+      "post": {
+        "x-preview-feature": true,
+        "description": "Scrap a ship, removing it from the game and returning a portion of the ship's value to the agent. The ship must be docked in a waypoint that has the `Shipyard` trait in order to use this function. To preview the amount of value that will be returned, use the Get Ship action.",
+        "operationId": "scrap-ship",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "",
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "agent": {
+                          "$ref": "../models/Agent.json"
+                        },
+                        "transaction": {
+                          "$ref": "../models/ScrapTransaction.json"
+                        }
+                      },
+                      "required": [
+                        "agent",
+                        "transaction"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Ship scrapped successfully."
+          }
+        },
+        "security": [
+          {
+            "AgentToken": []
+          }
+        ],
+        "summary": "Scrap Ship",
+        "tags": [
+          "Fleet"
+        ]
+      }
+    },
+    "/my/ships/{shipSymbol}/repair": {
+      "parameters": [
+        {
+          "description": "The ship symbol.",
+          "in": "path",
+          "name": "shipSymbol",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "x-preview-feature": true,
+        "description": "Get the cost of repairing a ship.",
+        "operationId": "get-repair-ship",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "",
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "transaction": {
+                          "$ref": "../models/RepairTransaction.json"
+                        }
+                      },
+                      "required": [
+                        "transaction"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successfully retrieved the cost of repairing a ship."
+          }
+        },
+        "security": [
+          {
+            "AgentToken": []
+          }
+        ],
+        "summary": "Get Repair Ship",
+        "tags": [
+          "Fleet"
+        ]
+      },
+      "post": {
+        "x-preview-feature": true,
+        "description": "Repair a ship, restoring the ship to maximum condition. The ship must be docked at a waypoint that has the `Shipyard` trait in order to use this function. To preview the cost of repairing the ship, use the Get action.",
+        "operationId": "repair-ship",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "",
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "agent": {
+                          "$ref": "../models/Agent.json"
+                        },
+                        "ship": {
+                          "$ref": "../models/Ship.json"
+                        },
+                        "transaction": {
+                          "$ref": "../models/RepairTransaction.json"
+                        }
+                      },
+                      "required": [
+                        "agent",
+                        "ship",
+                        "transaction"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Ship repaired successfully."
+          }
+        },
+        "security": [
+          {
+            "AgentToken": []
+          }
+        ],
+        "summary": "Repair Ship",
+        "tags": [
+          "Fleet"
+        ]
+      }
     }
   }
 }

--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -2196,12 +2196,23 @@
                         },
                         "cargo": {
                           "$ref": "../models/ShipCargo.json"
+                        },
+                        "events": {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "$ref": "../models/ShipConditionEvent.json"
+                              }
+                            ]
+                          }
                         }
                       },
                       "required": [
                         "extraction",
                         "cooldown",
-                        "cargo"
+                        "cargo",
+                        "events"
                       ],
                       "type": "object"
                     }
@@ -2259,12 +2270,23 @@
                         },
                         "cargo": {
                           "$ref": "../models/ShipCargo.json"
+                        },
+                        "events": {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "$ref": "../models/ShipConditionEvent.json"
+                              }
+                            ]
+                          }
                         }
                       },
                       "required": [
                         "siphon",
                         "cooldown",
-                        "cargo"
+                        "cargo",
+                        "events"
                       ],
                       "type": "object"
                     }
@@ -2573,11 +2595,22 @@
                         },
                         "nav": {
                           "$ref": "../models/ShipNav.json"
+                        },
+                        "events": {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "$ref": "../models/ShipConditionEvent.json"
+                              }
+                            ]
+                          }
                         }
                       },
                       "required": [
                         "nav",
-                        "fuel"
+                        "fuel",
+                        "events"
                       ],
                       "type": "object"
                     }


### PR DESCRIPTION
## Overview

Taking ship actions such as navigating and extracting will now have a chance of a negative event occurring which degrades the condition of the frame, reactor or engine on a ship. Better ships will degrade at a lower rate than cheap ships (the goal is to think of drones as almost disposable, but your command ship should be maintained).

All of the values for event frequency, repair cost, and scrap earnings are ballparked, so things will need to be adjusted from player feedback. Some of the design goals include:

- new players shouldn't need to worry too heavily about ship condition (so degraded performance is capped, allowing ships to continue to function non-optimally without becoming annoyingly slow or useless)
- cheap ships such as drones should be disposable, probably at a rate of daily or every other day.
- more expensive ships should be maintainable for weeks (so the entirety of the current reset)
- repairing your ships early should be cheaper than repairing as a last resort
- maintained ships should be less likely to take damage than poorly maintained ships
- ships should degrade permanently with each repair, forcing an eventual scrapping
- this feature should be more of a mid to late game optimization rather than something necessary to worry about early on
- act as a significant credit sink in the game to remove credits and entice finding new shipyards

## Negative Events

Currently only navigating and extracting have a chance of a negative event, but we will be adding most ship actions such as siphoning, docking, jumping, and warping into the logic. The traits of the waypoint involved currently increase the chances of a negative event (explosive gases for instance double the chances of damage to the ship)

## Ship Damage

Ships take damage from negative events which lower the condition of the affected component. The lower the condition of the component, the more damage that will incur over time, so it is beneficial to keep your important ships maintained. Higher quality ships, such as the command ship, will take less damage from events than cheaper ships, such as drones. The condition of a ship ranges from 0 to 1, and will be restored to 1 when repaired. The integrity of the component will degrade with each repair, and eventually it will make more sense to scrap a ship than repair it.

## Condition vs Integrity

Condition is repairable and is always restored to a value of 1. The integrity of the component is the long term wear and cannot be repaired. The integrity of the component is lowered every time you repair your ship.

## Scrapping

Scrapping your ship will provide your agent with credits relative to the cost of the ship, the condition of the components, the mounts and modules attached, and the current price of ship parts / plating at the shipyard. You won't get a great price for your mounts and modules, so you will likely want to remove anything valuable. Cargo will be destroyed and not factored into the credits given.

## Repairing

Repairing your ship costs credits and the cost of this repair will factor in the type of component, the condition of the component (more damaged components are more expensive to repair), and the price of ship parts and plating at the market.

## Changes

- adds endpoints for scrapping and repairing a ship (and GET requests for fetching an estimate)
- updates frame / reactor / engine condition to a float between 0 and 1
- adds an integrity value to frame / reactor / engine representing permanent wear
- adds events property to extract / siphon / navigate endpoints
- adds new event type for damage to ship condition