### PR TITLE
fix openapi json schema integrity

### DIFF
--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -3944,12 +3944,7 @@
                       "data"
                     ]
                   }
-                },
-                "application/xml": {
-                  "schema": {
-                    "type": "object",
-                    "properties": {}
-                  }
+                }
                 }
               }
             }

--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -3962,8 +3962,7 @@
               "AgentToken": []
             }
           ]
-        },
-        "parameters": []
+        }
       }
     }
   }

--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -3934,16 +3934,16 @@
                               }
                             }
                           }
-                        },
+                        }
+                      },
                         "required": [
                           "exportToImportMap"
                         ]
-                      }
-                    },
+                    }
+                  },
                     "required": [
                       "data"
                     ]
-                  }
                 }
                 }
               }

--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -10,7 +10,8 @@
     },
     "license": {
       "name": "No Permission",
-      "url": "https://choosealicense.com/no-permission/"
+      "url": "https://choosealicense.com/no-permission/",
+      "identifier": "No Permission"
     }
   },
   "security": [


### PR DESCRIPTION
There is a missing closing brace around the `market/supply` endpoint, making the JSON invalid. That also led to a duplicate `parameters` key/value.

Can check the formatting of the original w/ `jq . reference/SpaceTraders.json`

There was a seemingly unused `application/xml` definition as well for that endpoint. For the generators, 3.1.1 seems to want to have a license identifier (although that should be optional so far as I know) so I added it.

The openapi-generator-cli w/ ts client doesnt like 3.1.1 btw, so to get a client generated for myself I downgraded the schema to `3.0.3`

But this PR just fixes the schema integrity for what was merged in, with the additional changes of adding the `identifier` and removing the application/xml object.