### PR TITLE
Fix refuel ship example

### DIFF
--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -3133,7 +3133,7 @@
                   "units": {
                     "type": "integer",
                     "description": "The amount of fuel to fill in the ship's tanks. When not specified, the ship will be refueled to its maximum fuel capacity. If the amount specified is greater than the ship's remaining capacity, the ship will only be refueled to its maximum fuel capacity. The amount specified is not in market units but in ship fuel units.",
-                    "example": "100",
+                    "example": 100,
                     "minimum": 1
                   },
                   "fromCargo": {


### PR DESCRIPTION
The data type of `units` in the refuel example should be an integer instead of a string.