### PR TITLE
fix: use "number" instead of "double" for format

### DIFF
--- a/models/ShipComponentCondition.json
+++ b/models/ShipComponentCondition.json
@@ -1,6 +1,6 @@
 {
   "type": "number",
-  "format": "double",
+  "format": "number",
   "description": "The repairable condition of a component. A value of 0 indicates the component needs significant repairs, while a value of 1 indicates the component is in near perfect condition. As the condition of a component is repaired, the overall integrity of the component decreases.",
   "minimum": 0,
   "maximum": 1

--- a/models/ShipComponentIntegrity.json
+++ b/models/ShipComponentIntegrity.json
@@ -1,6 +1,6 @@
 {
   "type": "number",
-  "format": "double",
+  "format": "number",
   "description": "The overall integrity of the component, which determines the performance of the component. A value of 0 indicates that the component is almost completely degraded, while a value of 1 indicates that the component is in near perfect condition. The integrity of the component is non-repairable, and represents permanent wear over time.",
   "minimum": 0,
   "maximum": 1


### PR DESCRIPTION
The server sends down 'condition: 1' even though the format is listed as 'double' which at least the Dart OpenAPI generator treats very strictly as a floating point which '1' does not parse as (it parses as an integer).  OpenAPI does seem to have distinct types for "integer", "number" and "double", since the server isn't always including the dot, I guess this type should be "number".  At least that would fix the current OpenAPI dart generator. If you believe the open api generator is at fault, I'm open to fixing that instead.