### PR TITLE
fix: remove the single use of a union type in the api

### DIFF
--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -498,17 +498,10 @@
             "in": "query",
             "name": "traits",
             "schema": {
-              "oneOf": [
-                {
-                  "$ref": "../models/WaypointTraitSymbol.json"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "../models/WaypointTraitSymbol.json"
-                  }
-                }
-              ]
+              "type": "array",
+              "items": {
+                "$ref": "../models/WaypointTraitSymbol.json"
+              }
             }
           },
           {


### PR DESCRIPTION
Union types are easy in typescript, but harder in languages
like rust, c++, dart, etc.  The Dart openapi generator doesn't
currently support oneOf (that could be fixed), and since this is
the only place it's used it seems like a low cost to remove it.

The cost is mild ergnomics for easier generation by language that
lack union types (at least with generators that generate a type
for every argument declaration).