### PR TITLE
fix: supply-chain exportToImportMap value type

### DIFF
--- a/reference/SpaceTraders.json
+++ b/reference/SpaceTraders.json
@@ -3517,12 +3517,10 @@
                       "properties": {
                         "exportToImportMap": {
                           "type": "object",
-                          "properties": {
-                            "string": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
+                          "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
                             }
                           }
                         }


### PR DESCRIPTION
This looks like it was just generated wrong.  The response
uses a Map<String, List<String>> for which the openapi syntax
appears to be to put the value type in "additionalProperties"
which I've done here.